### PR TITLE
Addition of oauth2 library flag to support access to /userinfo.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-openid-oauth20",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-openid-oauth20",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "OAuth 2.0 authentication strategy for OpenID profiles for Passport.",
   "keywords": [
     "passport",

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -73,6 +73,7 @@ export class Strategy extends OAuth2Strategy {
    *   - `displayName`
    */
   userProfile(accessToken: string, done: Function) {
+    this._oauth2.useAuthorizationHeaderforGET(true);
     this._oauth2.get(this.userProfileURL, accessToken, (err, body, res) => {
       var json;
       if (err) {


### PR DESCRIPTION
According to OAuth2 docs user token should be passed in `Authorization: Bearer %token%` format. Currently, it passed as `Authorization: %token%`. This pull request fixing this problem.